### PR TITLE
Accept to parse torrents sent as "text/html"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ const fetchTorrent = (url, referer) => {
 
                 return response.blob();
             }).then((buffer) => {
-                if (buffer.type.match(/(application\/x-bittorrent|application\/octet-stream)/)) {
+                if (buffer.type.match(/(application\/x-bittorrent|application\/octet-stream|text\/html)/)) {
                     getTorrentName(buffer).then((name) => resolve({
                         torrent: buffer,
                         torrentName: name,


### PR DESCRIPTION
Hi.

I had a problem with the torrents of a tracker that resulted in a "Failed to read torrent" error.

The type of the data sent was "text / html", that is why torrent-control did not parse it.
So I simply modified the regex to accept this type of data.

However, as we can not know how trackers choose to send their data, maybe we can accept any type and let the bittorrent client generate an error if the content of the bytes is not a valid torrent? 