### PR TITLE
Add Vuze (formerly Azureus) support

### DIFF
--- a/src/lib/vuze_webui.js
+++ b/src/lib/vuze_webui.js
@@ -1,0 +1,81 @@
+class VuzeWebUIApi extends BaseClient {
+
+    constructor(serverSettings) {
+        super();
+
+        this.settings = {
+            apiVersion: 2,
+            ...serverSettings
+        };
+        this.cookie = null;
+    }
+
+    logIn() {
+        const {username, password} = this.settings;
+
+        if (username && password)
+            this.addAuthRequiredListener(username, password);
+
+        return Promise.resolve();
+    }
+
+    logOut() {
+        this.removeEventListeners();
+
+        return Promise.resolve();
+    }
+
+    addTorrent(torrent, options = {}) {
+        const {hostname} = this.settings;
+
+        return new Promise((resolve, reject) => {
+            
+            var empty_file = new File([''], '');
+            
+            let form = new FormData();
+            form.append('upfile_1', empty_file, '');
+            form.append('upfile_0', torrent, 'temp.torrent');
+
+            fetch(hostname + 'index.tmpl?d=u&local=1', {
+                method: 'POST',
+                credentials: 'include',
+                body: form
+            })
+            .then((response) => {
+                if (response.ok)
+                    return resolve();
+                else if (response.status === 400)
+                    throw new Error(chrome.i18n.getMessage('torrentAddError'));
+                else if (response.status === 401)
+                    throw new Error(chrome.i18n.getMessage('loginError'));
+                else
+                    throw new Error(chrome.i18n.getMessage('apiError', response.status.toString() + ': ' + response.statusText));
+            })
+            .catch((error) => reject(error));
+        });
+    }
+
+    addTorrentUrl(url, options = {}) {
+        const {hostname, apiVersion} = this.settings;
+        const addTorrentURLPath = (apiVersion === 2) ? 'index.ajax' : 'index.tmpl';
+
+        return new Promise((resolve, reject) => {
+            fetch(hostname + addTorrentURLPath + '?d=u&upurl=' + encodeURIComponent(url), {
+                method: 'GET',
+                credentials: 'include'
+            })
+            .then((response) => {
+                if (response.ok)
+                    return resolve();
+                else if (response.status === 400)
+                    throw new Error(chrome.i18n.getMessage('torrentAddError'));
+                else if (response.status === 401)
+                    throw new Error(chrome.i18n.getMessage('loginError'));
+                else
+                    throw new Error(chrome.i18n.getMessage('apiError', response.status.toString() + ': ' + response.statusText));
+            })
+            .catch((error) => reject(error));
+        });
+    }
+
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -49,6 +49,7 @@
       "lib/tixati.js",
       "lib/transmission.js",
       "lib/utorrent.js",
+      "lib/vuze_webui.js",
       "lib/qbittorrent.js",
       "util.js",
       "index.js"

--- a/src/util.js
+++ b/src/util.js
@@ -52,6 +52,22 @@ const clientList = [
         addressPlaceholder: 'http://127.0.0.1:8112/gui/'
     },
     {
+        id: 'vuze_remoteui',
+        name: 'Vuze Web Remote',
+        addressPlaceholder: 'http://127.0.0.1:9091/',
+        torrentOptions: ['paused', 'path']
+    },
+    {
+        id: 'vuze_webui',
+        name: 'Vuze HTML Web UI',
+        addressPlaceholder: 'http://127.0.0.1:6886/'
+    },
+    {
+        id: 'vuze_webui_100',
+        name: 'Vuze HTML Web UI (<1.0.0)',
+        addressPlaceholder: 'http://127.0.0.1:6886/'
+    },
+    {
         id: 'qbittorrent',
         name: 'qBittorrent',
         addressPlaceholder: 'http://127.0.0.1:8080/',
@@ -92,6 +108,15 @@ const getClient = (serverSettings) => {
             return new TransmissionApi(serverSettings);
         case 'utorrent':
             return new uTorrentApi(serverSettings);
+        case 'vuze_remoteui':
+            return new TransmissionApi(serverSettings);
+        case 'vuze_webui':
+            return new VuzeWebUIApi(serverSettings);
+        case 'vuze_webui_100':
+            return new VuzeWebUIApi({
+                apiVersion: 1,
+                ...serverSettings
+            });
         case 'qbittorrent':
             return new qBittorrentApi(serverSettings);
         case 'qbittorrent_404':


### PR DESCRIPTION
This adds support for some Vuze APIs.

- Vuze Web Remote can be used with the same API as Transmission.
See http://plugins.vuze.com/details/xmwebui
- Vuze HTML Web UI, stable version (currently 0.7.7)
See http://plugins.vuze.com/details/azhtmlwebui
- Vuze HTML Web UI Beta (currently 1.0.2).
See http://plugins.vuze.com/details/azhtmlwebui2