### PR TITLE
add skip hash option for qbittorrent

### DIFF
--- a/src/lib/qbittorrent.js
+++ b/src/lib/qbittorrent.js
@@ -86,6 +86,9 @@ export default class qBittorrentApi extends BaseClient {
 
                 if (options.firstLastPiecePrio)
                     form.append('firstLastPiecePrio', 'true');
+
+                if (options.skip_checking)
+                    form.append('skip_checking', 'true');
             } else {
                 form.append('torrents', torrent, 'temp.torrent');
             }
@@ -127,6 +130,9 @@ export default class qBittorrentApi extends BaseClient {
 
                 if (options.firstLastPiecePrio)
                     form.append('firstLastPiecePrio', 'true');
+
+                if (options.skip_checking)
+                    form.append('skip_checking', 'true');
             }
 
             fetch(hostname + addTorrentUrlPath, {

--- a/src/util.js
+++ b/src/util.js
@@ -92,6 +92,10 @@ export const clientList = [
             {
                 name: 'firstLastPiecePrio',
                 description: chrome.i18n.getMessage('firstLastPiecePriorityOption')
+            },
+            {
+                name: 'skip_checking',
+                description: chrome.i18n.getMessage('skipHashCheckOption')
             }
         ]
     },

--- a/test/lib/qbittorrent.test.js
+++ b/test/lib/qbittorrent.test.js
@@ -119,6 +119,7 @@ describe('qBittorrentApi', () => {
             label: 'Test',
             sequentialDownload: true,
             firstLastPiecePrio: true,
+            skip_checking: true,
         });
 
         expect(fetchMock.calls().length).to.equal(1);
@@ -130,6 +131,7 @@ describe('qBittorrentApi', () => {
             category: 'Test',
             sequentialDownload: 'true',
             firstLastPiecePrio: 'true',
+            skip_checking: 'true',
         });
     });
 
@@ -167,6 +169,7 @@ describe('qBittorrentApi', () => {
             label: 'Test',
             sequentialDownload: true,
             firstLastPiecePrio: true,
+            skip_checking: true,
         });
 
         expect(fetchMock.calls().length).to.equal(1);
@@ -178,6 +181,7 @@ describe('qBittorrentApi', () => {
             category: 'Test',
             sequentialDownload: 'true',
             firstLastPiecePrio: 'true',
+            skip_checking: true,
         });
     });
 


### PR DESCRIPTION
added the option for skipping hash check for qbittorrent in the server preferences section