### PR TITLE
Add support for form based logins to ruTorrent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -498,7 +498,7 @@ export const notification = (message) => {
 
     chrome.notifications.create({
         type: 'basic',
-        iconUrl: chrome.extension.getURL('icon/default-48.png'),
+        iconUrl: chrome.runtime.getURL('icon/default-48.png'),
         title: 'Torrent Control',
         message: message
     }, (id) => setTimeout(() => chrome.notifications.clear(id), 3000));

--- a/src/lib/rutorrent.js
+++ b/src/lib/rutorrent.js
@@ -9,12 +9,83 @@ export default class ruTorrentApi extends BaseClient {
     }
 
     logIn() {
-        const {username, password} = this.settings;
+        const {username, password, hostname} = this.settings;
 
-        if (username && password)
-            this.addAuthRequiredListener(username, password);
+        // No authentication provided
+        if (!(username && password))
+            return Promise.resolve();
 
-        return Promise.resolve();
+
+        // HTTP Basic Auth
+        this.addAuthRequiredListener(username, password);
+
+
+        // Form Auth
+        return new Promise((resolve, reject) => {
+            fetch(hostname, {
+                method: 'GET',
+                credentials: 'include',
+            })
+            .then((response) => {
+                response.text().then((html) => {
+                    const page = (new DOMParser()).parseFromString(html, 'text/html');
+
+                    // Use HTML autocomplete auttributes to complete many different login forms
+                    // regardless of what they look like
+                    const usernameInput = page.querySelector('[autocomplete="username"]');
+                    const passwordInput = page.querySelector('[autocomplete="current-password"]');
+
+                    // Failed to detect Form Auth
+                    // a. This endpoint does not use Form Auth
+                    // b. Form Auth used but already logged in
+                    // In both cases, do nothing
+                    if (usernameInput === null || passwordInput === null) {
+                        resolve();
+                        return;
+                    }
+
+                    // Populate the username and password fields
+                    usernameInput.value = username;
+                    passwordInput.value = password;
+
+                    // DOMParser scopes relative to the extension
+                    // Inject a base tag saying the scope should be relative to the
+                    // login page we fetched
+                    const base = page.createElement('base');
+                    base.href = response.url;
+                    page.head.appendChild(base);
+
+                    // Submit the login form
+                    let loginForm = new FormData(passwordInput.form);
+                    fetch(passwordInput.form.action, {
+                        method: passwordInput.form.method.toUpperCase(),
+                        credentials: 'include',
+                        body: loginForm,
+                    })
+                    .then((response) => {
+                        // Indicate failure from a bad response code
+                        if (response.status >= 400)
+                            throw new Error(chrome.i18n.getMessage('loginError'));
+
+                        response.text().then((html) => {
+                            const after_login = (new DOMParser()).parseFromString(html, 'text/html');
+                            if (after_login.querySelector('[autocomplete="current-password"]')) {
+                                // If the next page after logging in is still asking for the password
+                                // It's quite likely we failed to login
+                                throw new Error(chrome.i18n.getMessage('loginError'));
+                            } else{
+                                // No more input asking for a password autocomplete
+                                // (hopefully) means we logged in successfully
+                                resolve();
+                            }
+                        })
+                    })
+                    .catch((error) => reject(error));
+                })
+                .catch((error) => reject(error));
+            })
+            .catch((error) => reject(error));
+        });
     }
 
     logOut() {
@@ -28,7 +99,7 @@ export default class ruTorrentApi extends BaseClient {
 
         return new Promise((resolve, reject) => {
             let form = new FormData();
-            form.append('torrent_file', torrent, 'temp.torrent');
+            form.append('torrent_file[]', torrent, 'temp.torrent');
 
             if (options.paused)
                 form.append('torrents_start_stopped', options.paused.toString());

--- a/test/lib/rutorrent.test.js
+++ b/test/lib/rutorrent.test.js
@@ -29,6 +29,14 @@ describe('ruTorrentApi', () => {
     });
 
     it('Login', async () => {
+        fetchMock.getOnce('https://example.com:1234/', {
+            status: 200,
+            body: {
+                // ruTorrent HTML is here: https://github.com/Novik/ruTorrent/blob/master/index.html
+                result: '<html></html>',
+            },
+        });
+
         await instance.logIn();
 
         expect(chrome.webRequest.onAuthRequired.addListener.calledOnce).to.equal(true);
@@ -59,7 +67,7 @@ describe('ruTorrentApi', () => {
         expect(fetchMock.calls().length).to.equal(1);
         expect(fetchMock.lastOptions().method).to.equal('POST');
         expect(fetchMock.lastOptions().body).to.deep.equal({
-            torrent_file: torrentFile,
+            "torrent_file[]": torrentFile,
         });
     });
 
@@ -83,7 +91,7 @@ describe('ruTorrentApi', () => {
         expect(fetchMock.calls().length).to.equal(1);
         expect(fetchMock.lastOptions().method).to.equal('POST');
         expect(fetchMock.lastOptions().body).to.deep.equal({
-            torrent_file: torrentFile,
+            "torrent_file[]": torrentFile,
             torrents_start_stopped: 'true',
             dir_edit: '/mnt/storage',
             label: 'Test',


### PR DESCRIPTION
While HTTP Basic Auth is the most common, some installations use a
HTML based login form that sets cookies to login to ruTorrent.

To support these use cases, we look for the standardized browser
autocomplete hints in the HTML to identify which form elements we
should fill (the same way a browser password autofill would). We
then submit the form automatically.

Because we are relying on the autocomplete hints, we can support
thousands of login form permutations without writing code that
expects any particular type of form.