### PR TITLE
Fix issues with Auth basic and IPV6 IP addresses

### DIFF
--- a/src/lib/baseclient.js
+++ b/src/lib/baseclient.js
@@ -22,31 +22,31 @@ export default class BaseClient {
     }
 
     addHeadersReceivedEventListener(listener) {
-        const {hostname} = this.settings;
+        const { hostname } = this.settings;
 
         this.listeners.onHeadersReceived = listener;
 
         chrome.webRequest.onHeadersReceived.addListener(
             this.listeners.onHeadersReceived,
-            {urls: [hostname.replace(/:\d+/, '') + '*']},
+            { urls: [hostname.replace(/:\d+(?=\/$)/, '') + '*'] },
             ['blocking', 'responseHeaders']
         );
     }
 
     addBeforeSendHeadersEventListener(listener) {
-        const {hostname} = this.settings;
+        const { hostname } = this.settings;
 
         this.listeners.onBeforeSendHeaders = listener;
 
         chrome.webRequest.onBeforeSendHeaders.addListener(
             this.listeners.onBeforeSendHeaders,
-            {urls: [hostname.replace(/:\d+/, '') + '*']},
+            { urls: [hostname.replace(/:\d+(?=\/$)/, '') + '*'] },
             ['blocking', 'requestHeaders']
         );
     }
 
     addAuthRequiredListener(username, password) {
-        const {hostname} = this.settings;
+        const { hostname } = this.settings;
 
         this.listeners.onAuthRequired = (details) => {
             if (this.pendingRequests.indexOf(details.requestId) !== -1)
@@ -71,18 +71,18 @@ export default class BaseClient {
 
         chrome.webRequest.onAuthRequired.addListener(
             this.listeners.onAuthRequired,
-            {urls: [hostname.replace(/:\d+/, '') + '*']},
+            { urls: [hostname.replace(/:\d+(?=\/$)/, '') + '*'] },
             ['blocking']
         );
 
         chrome.webRequest.onCompleted.addListener(
             this.listeners.onAuthCompleted,
-            {urls: [hostname.replace(/:\d+/, '') + '*']},
+            { urls: [hostname.replace(/:\d+(?=\/$)/, '') + '*'] },
         );
 
         chrome.webRequest.onErrorOccurred.addListener(
             this.listeners.onAuthCompleted,
-            {urls: [hostname.replace(/:\d+/, '') + '*']},
+            { urls: [hostname.replace(/:\d+(?=\/$)/, '') + '*'] },
         );
     }
 


### PR DESCRIPTION
Fixes the regex parsing colons inside IPV6 IP addresses to remove the port from the hostname instead of parsing the colon that separates the port from the IP at the end of the hostname. It caused the extension to fail when using Auth Basic with a server that used an IPV6 IP as Server Address. 

Fixes #133