### PR TITLE
close blank tab after clicking magnet url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -477,6 +477,7 @@ const registerHandler = () => {
                     ...clientOptions
                 });
             }
+            chrome.tabs.remove(details.tabId)
             return {cancel: true}
         },
         {urls: ['https://torrent-control.invalid/*']},


### PR DESCRIPTION
fixes #155 by closing the tab instead of leaving it open