### PR TITLE
custom auth token for transmission

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -250,5 +250,13 @@
   "serverDefaultLabelOption": {
     "message": "Default label",
     "description": "Server default label option"
+  },
+  "authTokenOption": {
+    "message": "Use Custom Auth Key (required for some proxies)",
+    "description": "Auth token option"
+  },
+  "authTokenInputLabel": {
+    "message": "Token",
+    "description": "Auth token value label"
   }
 }

--- a/src/lib/transmission.js
+++ b/src/lib/transmission.js
@@ -16,11 +16,18 @@ export default class TransmissionApi extends BaseClient {
         this._attachListeners();
 
         return new Promise((resolve, reject) => {
+            const {clientOptions} = this.settings;
+            const headers = new Headers({
+                'Content-Type': 'application/json'
+            });
+
+            if (clientOptions && clientOptions.authToken) {
+                headers.append('Authorization', clientOptions.authToken);
+            }
+
             fetch(hostname + 'transmission/rpc', {
                 method: 'POST',
-                headers: new Headers({
-                    'Content-Type': 'application/json'
-                }),
+                headers: headers,
                 body: JSON.stringify({
                     method: 'session-get'
                 })
@@ -80,6 +87,12 @@ export default class TransmissionApi extends BaseClient {
                 if (this.session) {
                     headers.append('X-Transmission-Session-Id', this.session);
                 }
+                
+                const {clientOptions} = this.settings;
+                
+                if (clientOptions && clientOptions.authToken) {
+                    headers.append('Authorization', clientOptions.authToken);
+                }
 
                 return fetch(hostname + 'transmission/rpc', {
                     method: 'POST',
@@ -123,6 +136,12 @@ export default class TransmissionApi extends BaseClient {
 
             if (this.session) {
                 headers.append('X-Transmission-Session-Id', this.session);
+            }
+
+            const {clientOptions} = this.settings;
+
+            if (clientOptions && clientOptions.authToken) {
+                headers.append('Authorization', clientOptions.authToken);
             }
 
             fetch(hostname + 'transmission/rpc', {

--- a/src/util.js
+++ b/src/util.js
@@ -71,7 +71,16 @@ export const clientList = [
         id: 'transmission',
         name: 'Transmission',
         addressPlaceholder: 'http://127.0.0.1:9091/',
-        clientCapabilities: ['paused', 'label', 'path', 'httpAuth']
+        clientCapabilities: ['paused', 'label', 'path', 'httpAuth'],
+        clientOptions: [
+            {
+                name: 'authToken',
+                description: chrome.i18n.getMessage('authTokenOption'),
+                type: 'text',
+                toggle: true,
+                inputLabel: chrome.i18n.getMessage('authTokenInputLabel')
+            }
+        ]
     },
     {
         id: 'ttorrent',

--- a/test/env.js
+++ b/test/env.js
@@ -9,7 +9,28 @@ global.chrome = chrome;
 const jsdom = new JSDOM.JSDOM();
 global.DOMParser = jsdom.window.DOMParser;
 global.FileReader = jsdom.window.FileReader;
-global.Headers = jsdom.window.Headers;
+global.Headers = class Headers {
+    constructor(init) {
+        this.map = new Map();
+        if (init) {
+            for (const key in init) {
+                this.map.set(key.toLowerCase(), init[key]);
+            }
+        }
+    }
+    append(name, value) {
+        this.map.set(name.toLowerCase(), value);
+    }
+    get(name) {
+        return this.map.get(name.toLowerCase()) || null;
+    }
+    has(name) {
+        return this.map.has(name.toLowerCase());
+    }
+    entries() {
+        return this.map.entries();
+    }
+};
 
 global.FormData = class FormData {
     append(name, value) {

--- a/test/lib/transmission.test.js
+++ b/test/lib/transmission.test.js
@@ -208,9 +208,7 @@ describe('TransmissionApi', () => {
 
     it('Manual Auth Token', async () => {
         instance = new TransmissionApi({
-            username: 'testuser',
-            password: 'testpassw0rd',
-            hostname: 'https://example.com:1234/transmission/rpc',
+            hostname: 'https://example.com:1234/',
             clientOptions: {
                 authToken: 'Bearer my-secret-token'
             }

--- a/test/lib/transmission.test.js
+++ b/test/lib/transmission.test.js
@@ -205,4 +205,35 @@ describe('TransmissionApi', () => {
             },
         });
     });
+
+    it('Manual Auth Token', async () => {
+        instance = new TransmissionApi({
+            username: 'testuser',
+            password: 'testpassw0rd',
+            hostname: 'https://example.com:1234/transmission/rpc',
+            clientOptions: {
+                authToken: 'Bearer my-secret-token'
+            }
+        });
+
+        const fetchStub= sinon.stub(global, 'fetch');
+
+        fetchStub.resolves({
+            ok: true,
+            status: 200,
+            headers: new Headers({
+                'content-type': 'application/json',
+            }),
+            json: () => Promise.resolve({
+                result: 'success',
+            }),
+        });
+
+        await instance.logIn();
+
+        expect(fetchStub.calledOnce).to.be.true;
+        expect(fetchStub.firstCall.args[0]).to.equal('https://example.com:1234/transmission/rpc');
+        expect(fetchStub.firstCall.args[1].method).to.equal('POST');
+        expect(fetchStub.firstCall.args[1].headers.get('Authorization')).to.equal('Bearer my-secret-token');
+    });
 });


### PR DESCRIPTION
Add a custom auth token for cases where login requires it (e.g. shared seedboxes, oAuth).

This might be extended for all clients, I use transmission myself.