### PR TITLE
Feature/196 manual download path option

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -203,6 +203,10 @@
     "message": "Download directory",
     "description": "Download directory select"
   },
+  "customDownloadDirectoryOption": {
+    "message": "Custom path",
+    "description": "Manual download path text input label"
+  },
   "defaultOption": {
     "message": "Default",
     "description": "Default option"

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -203,6 +203,9 @@
     "message": "Lataushakemisto",
     "description": "Download location select"
   },
+  "customDownloadDirectoryOption": {
+    "message": "Custom path"
+  },
   "defaultOption": {
     "message": "Oletus",
     "description": "Default option"

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -204,7 +204,8 @@
     "description": "Download location select"
   },
   "customDownloadDirectoryOption": {
-    "message": "Custom path"
+    "message": "Mukautettu polku",
+    "description": "Manual download path text input label"
   },
   "defaultOption": {
     "message": "Oletus",

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -203,6 +203,9 @@
     "message": "Путь загрузки",
     "description": "Download location select"
   },
+  "customDownloadDirectoryOption": {
+    "message": "Custom path"
+  },
   "defaultOption": {
     "message": "По умолчанию",
     "description": "Default option"

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -204,7 +204,8 @@
     "description": "Download location select"
   },
   "customDownloadDirectoryOption": {
-    "message": "Custom path"
+    "message": "Произвольный путь",
+    "description": "Manual download path text input label"
   },
   "defaultOption": {
     "message": "По умолчанию",

--- a/src/view/add_torrent.html
+++ b/src/view/add_torrent.html
@@ -33,6 +33,11 @@
         </div>
 
         <div class="panel-formElements-item browser-style">
+            <label for="directory-input" data-i18n="customDownloadDirectoryOption"></label>
+            <input id="directory-input" type="text" class="browser-style" />
+        </div>
+
+        <div class="panel-formElements-item browser-style">
             <label for="labels" data-i18n="labelSelect"></label>
             <select id="labels" class="browser-style">
                 <option data-i18n="noneOption" value=""></option>

--- a/src/view/add_torrent.js
+++ b/src/view/add_torrent.js
@@ -43,6 +43,7 @@ const selectServer = (serverId) => {
     const client = clientList.find((client) => client.id === serverOptions.application);
 
     const directorySelect = document.querySelector('#directories');
+    const directoryInput = document.querySelector('#directory-input');
 
     for (let i = directorySelect.options.length - 1; i >= 1; i--) {
         directorySelect.remove(i);
@@ -61,9 +62,14 @@ const selectServer = (serverId) => {
         if (serverOptions.defaultDirectory) {
             directorySelect.value = serverOptions.defaultDirectory;
         }
+
+        directoryInput.value = serverOptions.defaultDirectory || '';
+        directoryInput.disabled = false;
     } else {
         directorySelect.value = '';
         directorySelect.disabled = true;
+        directoryInput.value = '';
+        directoryInput.disabled = true;
     }
 
     const labelSelect = document.querySelector('#labels');
@@ -85,12 +91,15 @@ const selectServer = (serverId) => {
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.querySelector('#server').addEventListener('change', (e) => selectServer(~~e.currentTarget.value));
+document.querySelector('#directories').addEventListener('change', (e) => {
+    document.querySelector('#directory-input').value = e.currentTarget.value;
+});
 document.querySelector('#add-torrent').addEventListener('click', (e) => {
     e.preventDefault();
 
     const params = new URLSearchParams(window.location.search);
     const label = document.querySelector('#labels').value;
-    const path = document.querySelector('#directories').value;
+    const path = document.querySelector('#directory-input').value;
     const addPaused = document.querySelector('#addpaused').checked;
     const server = document.querySelector('#server').value;
 


### PR DESCRIPTION
Implements https://github.com/Mika-/torrent-control/issues/196

Add a new text input to the "Add Torrent (advanced)" dialogue where the user can enter a custom path if needed.

The select of the pre-configured paths still works and now fills the new text input so that the user can choose one of the pre-configured paths and manually add more to the path. 

All old functionality of the dialogue still works since manually changing the path in the new input filed is completely optional.