### PR TITLE
Fix false 'Failed to login' on ruTorrent v4 (#152)

### DIFF
--- a/src/lib/baseclient.js
+++ b/src/lib/baseclient.js
@@ -4,7 +4,7 @@ export default class BaseClient {
 
     constructor() {
         this.listeners = {};
-        this.pendingRequests = [];
+        this.pendingRequests = {};
     }
 
     logIn() {
@@ -50,11 +50,20 @@ export default class BaseClient {
     addAuthRequiredListener(username, password) {
         const { hostname } = this.settings;
 
+        // Some clients (eg. ruTorrent v4) redirect to a different URL after a
+        // POST that requires authentication. Browsers re-use the same requestId
+        // across redirects, so we must allow more than one credential prompt
+        // per requestId — but cap the number of attempts to avoid an infinite
+        // retry loop when the credentials are actually wrong.
+        const maxAuthAttempts = 2;
+
         this.listeners.onAuthRequired = (details) => {
-            if (this.pendingRequests.indexOf(details.requestId) !== -1)
+            const attempts = (this.pendingRequests[details.requestId] || 0) + 1;
+
+            if (attempts > maxAuthAttempts)
                 return;
 
-            this.pendingRequests.push(details.requestId);
+            this.pendingRequests[details.requestId] = attempts;
 
             return {
                 authCredentials: {
@@ -65,10 +74,7 @@ export default class BaseClient {
         };
 
         this.listeners.onAuthCompleted = (details) => {
-            let index = this.pendingRequests.indexOf(details.requestId);
-
-            if (index > -1)
-                this.pendingRequests.splice(index, 1);
+            delete this.pendingRequests[details.requestId];
         };
 
         chrome.webRequest.onAuthRequired.addListener(

--- a/test/lib/rutorrent.test.js
+++ b/test/lib/rutorrent.test.js
@@ -27,6 +27,36 @@ describe('ruTorrentApi', () => {
         expect(chrome.webRequest.onErrorOccurred.addListener.calledOnce).to.equal(true);
     });
 
+    it('Login re-supplies credentials across redirects', async () => {
+        const authInstance = new ruTorrentApi({
+            username: 'testuser',
+            password: 'testpassw0rd',
+            hostname: 'https://example.com:1234/',
+            clientOptions: {
+                authType: 'httpAuth',
+                fast_resume: false,
+            },
+        });
+
+        await authInstance.logIn();
+
+        const onAuthRequired = chrome.webRequest.onAuthRequired.addListener.firstCall.args[0];
+
+        // Simulated first 401 challenge for a POST.
+        const first = onAuthRequired({ requestId: '42' });
+        expect(first.authCredentials.username).to.equal('testuser');
+
+        // ruTorrent v4 issues a 302 redirect after a successful POST; the
+        // browser follows the redirect with the same requestId and the server
+        // challenges again. We must keep supplying credentials.
+        const second = onAuthRequired({ requestId: '42' });
+        expect(second.authCredentials.username).to.equal('testuser');
+
+        // Cap retries to avoid an infinite loop when the credentials are wrong.
+        const third = onAuthRequired({ requestId: '42' });
+        expect(third).to.be.undefined;
+    });
+
     it('Login form', async () => {
         const authInstance = new ruTorrentApi({
             username: 'testuser',


### PR DESCRIPTION
## Summary
- ruTorrent v4 returns a 302 redirect after the POST to `addtorrent.php`. The browser follows the redirect under the same `requestId`, gets challenged again, and the existing `onAuthRequired` guard prevented re-supplying credentials — so the follow-up GET returned 401 and surfaced a false "Failed to login" notification even though the torrent was added.
- Allow up to 2 auth attempts per `requestId` (covers one redirect) while still capping retries to avoid loops on bad credentials.

Fixes #152

## Test plan
- [x] `npm test` (108 passing)
- [ ] Manual: add a magnet via context menu against ruTorrent v4 with HTTP auth — no error notification, torrent appears in client
- [ ] Manual: verify bad credentials still surface an error (no infinite loop)